### PR TITLE
lrucache: fix race condition in tests

### DIFF
--- a/lrucache/lrucache_test.go
+++ b/lrucache/lrucache_test.go
@@ -243,8 +243,8 @@ func TestExtra(t *testing.T) {
 	}
 
 	now := time.Now()
-	b.Set("b", "vb", now)
-	b.Set("a", "va", now)
+	b.Set("b", "vb", now.Add(time.Duration(-2*time.Second)))
+	b.Set("a", "va", now.Add(time.Duration(-1*time.Second)))
 	b.Set("c", "vc", now.Add(time.Duration(3*time.Second)))
 
 	if v, _ := b.Get("a"); v != "va" {


### PR DESCRIPTION
"a" and "b" expiration time is set to time.Now(), and they are expected to be expired but the test code is running very fast and .Before(now) returns false.

I've ran this test on: i7-3770k and go version go1.4.2 windows/amd64