### PR TITLE
For #7: Prevent overflow comparing int to MaxUint32 on 32-bit sys, without limiting to MaxInt32 on 64-bit

### DIFF
--- a/bytepool/bytepool.go
+++ b/bytepool/bytepool.go
@@ -23,10 +23,15 @@ type BytePool struct {
 // drainPeriod is non zero. MaxSize specifies the maximum length of a
 // byte slice that should be cached (rounded to the next power of 2).
 func (tp *BytePool) Init(drainPeriod time.Duration, maxSize uint32) {
+	if maxSize > math.MaxUint32 {
+		maxSize = math.MaxUint32
+	}
 	maxSizeLog := log2Ceil(maxSize)
 	tp.maxSize = (1 << maxSizeLog) - 1
-	if tp.maxSize > math.MaxUint32 {
-		tp.maxSize = math.MaxUint32
+	// 32-bit catch
+	if tp.maxSize <= 0 {
+		tp.maxSize = math.MaxInt32
+		maxSizeLog = log2Ceil(math.MaxInt32)
 	}
 	tp.list_of_pools = make([]pool, maxSizeLog+1)
 	if drainPeriod > 0 {

--- a/bytepool/bytepool_test.go
+++ b/bytepool/bytepool_test.go
@@ -90,7 +90,8 @@ func TestDrain(t *testing.T) {
 func TestLimits(t *testing.T) {
 	t.Parallel()
 
-	var p BytePool
+	var ti	int
+	var p 	BytePool
 	p.Init(0, 127)
 
 	p.Put(make([]byte, 129))
@@ -119,6 +120,24 @@ func TestLimits(t *testing.T) {
 	p.Put(make([]byte, 129))
 	if p.entries() != 1 {
 		t.Fatal("expected different pool length")
+	}
+
+	p.Put(make([]byte, math.MaxUint32 + 1))
+	if p.entries() != 1 {
+		t.Fatal("expected the pool to have a single item")
+	}
+
+	p.Put(make([]byte, math.MaxInt32 + 1))
+	ti = (1 << log2Ceil(math.MaxUint32)) - 1
+	if ti <= 0 {
+		// 32-bit systems: Put() slice-size math.MaxInt32 + 1 fails
+		if p.entries() != 1 {
+			t.Fatal("expected the pool to have a single item")
+		}
+	} else {
+		if p.entries() != 2 {
+			t.Fatal("expected the pool to have two items")
+		}
 	}
 
 	p.Drain()


### PR DESCRIPTION
For #7: Prevent overflow comparing int to MaxUint32 on 32-bit sys, without limiting to MaxInt32 on 64-bit