### PR TITLE
fix make bench error 

### DIFF
--- a/lrucache/benchmark/vcache.go
+++ b/lrucache/benchmark/vcache.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	vcache "code.google.com/p/vitess/go/cache"
+	vcache "github.com/youtube/vitess/go/cache"
 )
 
 type VCache struct {
@@ -12,7 +12,7 @@ type VCache struct {
 
 func NewVCache(capacity uint64) *VCache {
 	return &VCache{
-		LRUCache: *vcache.NewLRUCache(capacity),
+		LRUCache: *vcache.NewLRUCache(int64(capacity)),
 	}
 }
 


### PR DESCRIPTION
error info as follow:

# github.com/cloudflare/golibs/lrucache/benchmark
./vcache.go:15: cannot use capacity (type uint64) as type int64 in argument to cache.NewLRUCache
Makefile:26: recipe for target 'bench' failed
make: *** [bench] Error 2