### PR TITLE
Fixed outdated vitess import reference.

### DIFF
--- a/lrucache/benchmark/vcache.go
+++ b/lrucache/benchmark/vcache.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	vcache "code.google.com/p/vitess/go/cache"
+	vcache "github.com/youtube/vitess/go/cache"
 )
 
 type VCache struct {
@@ -12,7 +12,7 @@ type VCache struct {
 
 func NewVCache(capacity uint64) *VCache {
 	return &VCache{
-		LRUCache: *vcache.NewLRUCache(capacity),
+		LRUCache: *vcache.NewLRUCache(int64(capacity)),
 	}
 }
 


### PR DESCRIPTION
A small patch to fix where `go get` fails to resolve the old vitess reference at lrucache/benchmark/vcache.go 
![screen shot 2016-12-15 at 13 09 49](https://cloud.githubusercontent.com/assets/8382009/21212525/719f5f76-c2c8-11e6-9917-5a28aab48ed7.png)

And it works.
![screen shot 2016-12-15 at 13 06 21](https://cloud.githubusercontent.com/assets/8382009/21212507/4571d154-c2c8-11e6-8a6f-dc077938dbb6.png)
