### PR TITLE
kt: Added a function to create a tracked conn from an existing conn

### DIFF
--- a/kt/kt_metrics.go
+++ b/kt/kt_metrics.go
@@ -42,6 +42,14 @@ func NewTrackedConn(host string, port int, poolsize int, timeout time.Duration,
 		opTimer: opTimer}, nil
 }
 
+// NewTrackedConnFromConn returns a tracked connection that simply wraps the given
+// database connection.
+func NewTrackedConnFromConn(conn *Conn, opTimer *prometheus.SummaryVec) (*TrackedConn, error) {
+	return &TrackedConn{
+		kt:      conn,
+		opTimer: opTimer}, nil
+}
+
 func (c *TrackedConn) Count() (int, error) {
 	start := time.Now()
 	defer func() {


### PR DESCRIPTION
The tracked connection utility currently needs full connection
parameters when actually it can just be wrapped around an existing
database connection.