### PR TITLE
lrucache: Removed reference to code.google.com

### DIFF
--- a/lrucache/benchmark/vcache.go
+++ b/lrucache/benchmark/vcache.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	vcache "code.google.com/p/vitess/go/cache"
+	vcache "github.com/youtube/vitess/go/cache"
 )
 
 type VCache struct {


### PR DESCRIPTION
The google code project is no longer up and running. I've replaced a reference to it.