### PR TITLE
Added graceful expiry period to GetNotStaleNow()

### DIFF
--- a/lrucache/multilru.go
+++ b/lrucache/multilru.go
@@ -23,6 +23,13 @@ func (m *MultiLRUCache) Init(buckets, bucket_capacity uint) {
 	}
 }
 
+// Set the stale expiry grace period for each cache in the multicache instance.
+func (m *MultiLRUCache) SetExpireGracePeriod(p time.Duration) {
+	for _, c := range m.cache {
+		c.ExpireGracePeriod = p
+	}
+}
+
 func NewMultiLRUCache(buckets, bucket_capacity uint) *MultiLRUCache {
 	m := &MultiLRUCache{}
 	m.Init(buckets, bucket_capacity)


### PR DESCRIPTION
Currently when an expired item is found via GetNotStaleNow() the item
will be removed immediately. This change introduces a new graceful check
which only forcibly removes items after a graceful time window, unless
they're pushed out of LRU.

(taken from rrdns e680857f3436de2325819e0898dfcafc426237b6)