### PR TITLE
kt: Switched opTimer in metrics to track in seconds

### DIFF
--- a/kt/kt_metrics.go
+++ b/kt/kt_metrics.go
@@ -28,7 +28,7 @@ const (
 
 // NewTrackedConn creates a new connection to a Kyoto Tycoon endpoint, and tracks
 // operations made to it using prometheus metrics.
-// All supported operations are tracked, opTimer times the number of nanoseconds
+// All supported operations are tracked, opTimer times the number of seconds
 // each type of operation took, generating a summary.
 func NewTrackedConn(host string, port int, poolsize int, timeout time.Duration,
 	opTimer *prometheus.SummaryVec) (*TrackedConn, error) {
@@ -54,7 +54,7 @@ func (c *TrackedConn) Count() (int, error) {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opGet).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opGet).Observe(since.Seconds())
 	}()
 
 	return c.kt.Count()
@@ -64,7 +64,7 @@ func (c *TrackedConn) Remove(key string) error {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opRemove).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opRemove).Observe(since.Seconds())
 	}()
 
 	return c.kt.Remove(key)
@@ -74,7 +74,7 @@ func (c *TrackedConn) GetBulk(keysAndVals map[string]string) error {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opGetBulk).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opGetBulk).Observe(since.Seconds())
 	}()
 
 	return c.kt.GetBulk(keysAndVals)
@@ -84,7 +84,7 @@ func (c *TrackedConn) Get(key string) (string, error) {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opGet).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opGet).Observe(since.Seconds())
 	}()
 
 	return c.kt.Get(key)
@@ -94,7 +94,7 @@ func (c *TrackedConn) GetBytes(key string) ([]byte, error) {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opGetBytes).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opGetBytes).Observe(since.Seconds())
 	}()
 
 	return c.kt.GetBytes(key)
@@ -104,7 +104,7 @@ func (c *TrackedConn) Set(key string, value []byte) error {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opSet).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opSet).Observe(since.Seconds())
 	}()
 
 	return c.kt.Set(key, value)
@@ -114,7 +114,7 @@ func (c *TrackedConn) GetBulkBytes(keys map[string][]byte) error {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opGetBulkBytes).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opGetBulkBytes).Observe(since.Seconds())
 	}()
 
 	return c.kt.GetBulkBytes(keys)
@@ -124,7 +124,7 @@ func (c *TrackedConn) SetBulk(values map[string]string) (int64, error) {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opSetBulk).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opSetBulk).Observe(since.Seconds())
 	}()
 
 	return c.kt.SetBulk(values)
@@ -134,7 +134,7 @@ func (c *TrackedConn) RemoveBulk(keys []string) (int64, error) {
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opRemoveBulk).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opRemoveBulk).Observe(since.Seconds())
 	}()
 
 	return c.kt.RemoveBulk(keys)
@@ -144,7 +144,7 @@ func (c *TrackedConn) MatchPrefix(key string, maxrecords int64) ([]string, error
 	start := time.Now()
 	defer func() {
 		since := time.Since(start)
-		c.opTimer.WithLabelValues(opMatchPrefix).Observe(float64(since.Nanoseconds()))
+		c.opTimer.WithLabelValues(opMatchPrefix).Observe(since.Seconds())
 	}()
 
 	return c.kt.MatchPrefix(key, maxrecords)


### PR DESCRIPTION
For consistency, this switches the `opTimer` metric to using seconds (with floating point precision) for tracking request latency.