### PR TITLE
kt: Do not send empty bodies

### DIFF
--- a/kt/kt.go
+++ b/kt/kt.go
@@ -337,11 +337,15 @@ func (c *Conn) roundTrip(method string, url *url.URL, headers http.Header, body 
 }
 
 func (c *Conn) makeRequest(method string, url *url.URL, headers http.Header, body []byte) (*http.Request, *time.Timer) {
+	var rc io.ReadCloser
+	if body != nil {
+		rc = ioutil.NopCloser(bytes.NewReader(body))
+	}
 	req := &http.Request{
 		Method:        method,
 		URL:           url,
 		Header:        headers,
-		Body:          ioutil.NopCloser(bytes.NewReader(body)),
+		Body:          rc,
 		ContentLength: int64(len(body)),
 	}
 	t := time.AfterFunc(c.timeout, func() {


### PR DESCRIPTION
The Go stdlib sends a request body if http.Request.Body is non-nil. If Request.Body.Read returns a zero-length buffer and io.EOF, an unnecessary empty chunk is sent. This empty chunk breaks net/http's retry behaviour.