### PR TITLE
kt: Retry on all errors, not just io.EOF

### DIFF
--- a/kt/kt.go
+++ b/kt/kt.go
@@ -317,10 +317,9 @@ func (c *Conn) doRPC(path string, values []KV) (code int, vals []KV, err error) 
 func (c *Conn) roundTrip(method string, url *url.URL, headers http.Header, body []byte) (*http.Response, *time.Timer, error) {
 	req, t := c.makeRequest(method, url, headers, body)
 	resp, err := c.transport.RoundTrip(req)
-	if err == io.EOF {
-		// The connection was closed by the server while it was idle,
-		// which happens during graceful shutdown. Close all idle connections
-		// and retry once.
+	if err != nil {
+		// Ideally we would only retry when we hit a network error. This doesn't work
+		// since net/http wraps some of these errors. Do the simple thing and retry eagerly.
 		t.Stop()
 		c.transport.CloseIdleConnections()
 		req, t = c.makeRequest(method, url, headers, body)


### PR DESCRIPTION
There are several errors in addition to io.EOF which net/http will return when connections in the pool are cut:

* http.errServerClosedIdle: returned if the request is not idempotent, possibly a race in net/http
* net.Errors: returned if request is written to connection closed by remote end

http.errServerClosedIdle is especially troublesome, since it isn't exported by net/http. Instead of kludging a check for the unexported error we simply retry on all errors.