### PR TITLE
bytepool: Document deprecation

### DIFF
--- a/bytepool/README.md
+++ b/bytepool/README.md
@@ -1,8 +1,7 @@
 BytePool
 --------
 
-A pool of byte slices. Similar in spirit to
-[`sync.Pool`](http://tip.golang.org/pkg/sync/#Pool) package.
+DEPRECATED. Use [`sync.Pool`](https://golang.org/pkg/sync/#Pool) instead.
 
 For discussion see this blog post:
 

--- a/bytepool/bytepool.go
+++ b/bytepool/bytepool.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2013 CloudFlare, Inc.
 
+// Package bytepool is deprecated
 package bytepool
 
 import (
@@ -22,6 +23,8 @@ type BytePool struct {
 // Initialize BytePool structure. Starts draining regularly if
 // drainPeriod is non zero. MaxSize specifies the maximum length of a
 // byte slice that should be cached (rounded to the next power of 2).
+//
+// Deprecated: Use sync.Pool from the stdlib instead.
 func (tp *BytePool) Init(drainPeriod time.Duration, maxSize uint32) {
 	maxSizeLog := log2Ceil(maxSize)
 	tp.maxSize = (1 << maxSizeLog) - 1


### PR DESCRIPTION
bytepool predates sync.Pool, and does not benefit from the same integration with the runtime. Let's deprecate it.