### PR TITLE
Fix remainder sync.Once var from removed sync import

### DIFF
--- a/kt/kt.go
+++ b/kt/kt.go
@@ -30,8 +30,6 @@ var certExpiryTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	},
 )
 
-var once sync.Once
-
 func init() {
 	prometheus.MustRegister(certExpiryTimestamp)
 }


### PR DESCRIPTION
Previous merge left a sync.Once var init that fails due to the removes sync import. This removes the var init and fixes the issue