### PR TITLE
do not create new 'err' when there is already one

### DIFF
--- a/kt/kt.go
+++ b/kt/kt.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -135,7 +136,7 @@ func loadCerts(creds string) (*tls.Certificate, *x509.CertPool, error) {
 		return nil, nil, err
 	}
 
-	err := expiryCertMetric(cert)
+	err = expiryCertMetric(cert)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This fixes following compiler error.

    kt/kt.go:138:6: no new variables on left side of :=

And add the missing import.

Fixes: 3c537d58cbb0d3c7df2081be376f581a00640d3d
Signed-off-by: Sami Kerola <kerolasa@iki.fi>