### PR TITLE
certPaths() needs to return absolute paths

### DIFF
--- a/kt/kt.go
+++ b/kt/kt.go
@@ -116,15 +116,19 @@ func certPaths(dir string) (cert, key, ca string, err error) {
 
 	for _, set := range certSets {
 		goodSet := true
-		for _, file := range set {
-			check := path.Join(dir, file)
-			if _, err := os.Stat(check); os.IsNotExist(err) {
+		cert = path.Join(dir, set[0])
+		key = path.Join(dir, set[1])
+		ca = path.Join(dir, set[2])
+
+		for _, file := range []string{cert, key, ca} {
+			if _, err := os.Stat(file); os.IsNotExist(err) {
 				goodSet = false
 				break
 			}
 		}
+
 		if goodSet {
-			return set[0], set[1], set[2], nil
+			return cert, key, ca, nil
 		}
 	}
 	return "", "", "", fmt.Errorf("there are no certificates in path: %s", dir)


### PR DESCRIPTION
The cert directory need to be part of the file paths, just like it was
before I started changing things.  This rather miserable change series goes
to show when you do something in hurry you end up fixing it longer than
taking the time in the first place.

Signed-off-by: Sami Kerola <kerolasa@iki.fi>